### PR TITLE
Modifies Rails API-only-application to work as a "regular" Rails Application

### DIFF
--- a/app/controllers/api/v1/athletes_controller.rb
+++ b/app/controllers/api/v1/athletes_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::AthletesController < ApplicationController
+class Api::V1::AthletesController < ApiController
 
   before_action :find_athlete_and_result
   before_action :authenticate_api_v1_user!, only: [:create, :destroy, :edit]

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::ResultsController < ApplicationController
+class Api::V1::ResultsController < ApiController
 
   def index
     render json: sorted_results, status: :ok

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,3 @@
+class ApiController < ActionController::API
+  include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
-class ApplicationController < ActionController::API
-  include DeviseTokenAuth::Concerns::SetUserByToken
+class ApplicationController < ActionController::Base
+  skip_before_action :verify_authenticity_token
 end

--- a/app/controllers/athletes_controller.rb
+++ b/app/controllers/athletes_controller.rb
@@ -1,4 +1,4 @@
-class AthletesController < ActionController::Base
+class AthletesController < ApplicationController
 
   def index
     sorted_results

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,6 @@ module Nbinvitational
       end
     end
     routes.default_url_options[:host] = 'https://votingapi.herokuapp.com'
-    config.api_only = true
+    # config.api_only = true
   end
 end

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,0 +1,1 @@
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -4,7 +4,7 @@ DeviseTokenAuth.setup do |config|
   # this to false to prevent the Authorization header from changing after
   # each request.
   # config.change_headers_on_each_request = true
-  config.enable_standard_devise_support = true
+  # config.enable_standard_devise_support = true
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,6 +36,36 @@ ActiveRecord::Schema.define(version: 2018_04_06_135041) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "admins", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.text "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_admins_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_admins_on_uid_and_provider", unique: true
+  end
+
   create_table "athletes", force: :cascade do |t|
     t.string "name"
     t.string "home"


### PR DESCRIPTION
#### Description
Changes proposed in this pull request:
* Fixes controllers / application to work not only as a API so that it can utilize requests.

#### What I have learned working on this feature: 
* To modify a Rails API-only application to work as a "regular" Rails Application